### PR TITLE
fixed sciencebeam alerts rules yaml syntax

### DIFF
--- a/releases/adm/sciencebeam-alert-rules.yaml
+++ b/releases/adm/sciencebeam-alert-rules.yaml
@@ -10,4 +10,4 @@ spec:
   - name: sciencebeam
     rules:
     - alert: ScienceBeamServerError
-      expr: "rate(nginx_ingress_controller_requests{exported_service=~"sciencebeam.*", status=~"5.*"}[10m]) > 0"
+      expr: 'rate(nginx_ingress_controller_requests{exported_service=~"sciencebeam.*", status=~"5.*"}[10m]) > 0'


### PR DESCRIPTION
I installed a local yaml validator now. Might still be worth to add a GitHub Action? e.g. https://github.com/marketplace/actions/yaml-schema-validator