### PR TITLE
Add an kubernetes autoscaler manager to the cluster

### DIFF
--- a/releases/autoscaler/autoscaler.yaml
+++ b/releases/autoscaler/autoscaler.yaml
@@ -1,0 +1,19 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: autoscaler
+  namespace: autoscaler
+
+spec:
+  releaseName: cluster-autoscaler
+  chart:
+    repository: https://kubernetes.github.io/autoscaler
+    name: cluster-autoscaler
+    version: 9.15.0
+
+  values:
+    autoDiscovery:
+      clusterName: flux-test
+      tags:
+      - kubernetes.io/cluster/kubernetes-aws--flux-test
+    awsRegion: us-east-1

--- a/releases/autoscaler/namespace.yaml
+++ b/releases/autoscaler/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: autoscaler


### PR DESCRIPTION
This is an attempt at running the kubernetes autoscaler in the test cluster.

This will probably fail anyway due to IAM permissions, but I want to see it on the cluster in action.

Also need to consider the impact of a moving `desired-capacity` value to the terraform output



