### PR TITLE
feature(alertmanager): break off the secrets from config - part 1

### DIFF
--- a/system/monitoring/prometheus-operator.yaml
+++ b/system/monitoring/prometheus-operator.yaml
@@ -78,6 +78,9 @@ spec:
         enabled: true
       alertmanagerSpec:
         configSecret: alertmanager-prometheus-operator
+        secrets:
+        - alertmanager-slack-receiver-api_url
+        - alertmanager-healthchecks-receiver-url
         replicas: 1
         resources:
           limits:

--- a/system/monitoring/secrets/alertmanager-healthchecks-receiver-url.yaml
+++ b/system/monitoring/secrets/alertmanager-healthchecks-receiver-url.yaml
@@ -1,0 +1,17 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: alertmanager-healthchecks-receiver-url
+  namespace: monitoring
+spec:
+  encryptedData:
+    healthchecks-receiver-url.yaml: AgBccf93WcWH3SHPdxxmdKqBpT8VNSgUQBQ3zG/YM7VwKol7cRhl7CDPGR4EevmPQUcHbBGt8LvddERCCXitT3FaeWnIC15jGq9Hx3bfC3sJKtx1mKiUU7woOz3E+/70tc+C56fqvWOt3GQksOkfH2JPvrdvq0TzIZrFhbkne/Io7A3p0nQGb7LGvCEiYdXsDE2gc4YuLOEA2Vhs0P0xSKF4pgX/F/DSCs+0zy7iHschdHTdVTQh7maUYH5ZKF7HhAKkkHSeOCGgmGbYOOgdssnQjwndBeoO1T6rHmL1HZgFGZBsfqgxO+Mp/kCvpFbuf2gVb46mrDfnqf02WcjjGPa9yazCt7rwkNUVAFsZsVqYZFU98dbUFX+/DJUosQacioldjWwdtEwXZarf7XR7OwB+EfFBvJ+3ViwouFEW/KEgY5S7T23wgul39TDAdYDmriAXIFyRMq7jmrYINRoQTxGI3I5uY3ObPBSXMFKLaKuds1iWswIIWJCXQabG8IeoU2dFvTYKUz6radJ4Q10aL9rz7t6OGozw4TnX5U50vrGdmV6Y58Cd9fvyymojgZ/o989hInUplRRjVJmTyNxshUT0Sz4qzGG88Yb9vLu98xs3SdGENZypy+FDN5ceytQFO6rK+vOOgHG/vVoF8eunFi/0ltKB6RjXbqXAAl/2X1nHHCdJodwaorPcizhDymtEUQlevuTvCj8+zo2Symnx2UPM4JLs1Nw8Ug2eRnLdbMaHIV0tz6uUHwAqovKbevt3zvNQ3j0UiHwls5SqlF36YDtCjIOS0rOQ0OQ81a98JvslgvJLsXRF5WTOz5W2tNsPD0grmV94EoLyTjc=
+  template:
+    data: null
+    metadata:
+      creationTimestamp: null
+      name: alertmanager-healthchecks-receiver-url
+      namespace: monitoring
+    type: Opaque
+

--- a/system/monitoring/secrets/alertmanager-slack-receiver-api_url.yaml
+++ b/system/monitoring/secrets/alertmanager-slack-receiver-api_url.yaml
@@ -1,0 +1,17 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: alertmanager-slack-receiver-api_url
+  namespace: monitoring
+spec:
+  encryptedData:
+    slack-receiver-api_url.yaml: AgAJZC89C8wgiqxaP5c+JzmkczvnAGVZdu/rr4r6gHE3R03SJtz2ejR5ZGZpn/Jhz72SRrpI7dWzN/BOW98Ko1ijr3BOTq93A96J2OmwmKo+GDOlowOTQM0mFfjYpaArHDKY/g/qffisDznQMNhCzXgaWYgjWeKyU0BAT6qHwMWquQTKaaYWuQUhHX8Xiv3F4tdWxAWA642OjLQfypeux4Mt6R/i4VximK9KNLt/mDBpQE5tYyxuVfwcEzU9aVHjq/IXIk+wnTx+6MRozIVK8feoDN5WtOmRPcogZXzbXzesFrEt98+1ruchoZRddY0246FKy+0co1PAl+rrNTHT2tI1i5ZngYLdjMNtLDRGUx39BB9ElpivinQphBVETyv7E0t4BdYxB1ZVgcVXWPrhtVP60+g6aB2/C03XUyGmj+nh/3+XbcaBOdGbLXX63YjlFIcdFNvOSy0FVg0+PdaRyLY104SMX6DGWiMh3KRhLzj8F/ovGCejd/XKtOMJCsVdlG8sZEE13A1xmggM8in2j/9n9eCVogqE58LeWG3FfEl+/5z7F1CYn/IftpFTWAUdwL+VcP+wUWylhnV5fk2LTnP5y6tHIj/jMwItmLRhG70fSohyd7picnpYYIEh1B8gQI9okYgLg+rJUoh2uyd0BSQxRUGsU6uaLJ9g4xlgf5fi4f7VDPucSES6qOUVOvVpytllrEwOS8XO7YoJJFR1gpq4nkZ+u48kUXBbhrnugLGghsjuGIN6ynhLfiAMxCNi+HQyi+Dcc1UE99d52qieLn1PoH8yub0l/RsXOOxTQhTY81tZ+/OZHkngpcTKV8kVCxsMWk4jGHGPaiiD/fhUWKVtSoJha327Quf7s+KvaQ==
+  template:
+    data: null
+    metadata:
+      creationTimestamp: null
+      name: alertmanager-slack-receiver-api_url
+      namespace: monitoring
+    type: Opaque
+


### PR DESCRIPTION
break off the secrets for slack and healthchecks.io into prometheus templates stored in sealedsecrets that can be included from the main config
Then move the config into a the helm chart for easier editing

This PR is just the first part, to make sure the secrets are created and mounted in the pods.