### PR TITLE
fix(ci): improve reliability of CI

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -44,16 +44,16 @@ jobs:
           kubectl wait kustomizations.kustomize.toolkit.fluxcd.io --for=condition=ready --timeout=10m -n flux-system deployments
       - name: Verify helm reconciliation
         run: |
-          kubectl wait helmreleases.helm.toolkit.fluxcd.io --for=condition=ready --timeout=10m -n autoscaler    cluster-autoscaler
-          kubectl wait helmreleases.helm.toolkit.fluxcd.io --for=condition=ready --timeout=10m -n infra         cert-manager
-          kubectl wait helmreleases.helm.toolkit.fluxcd.io --for=condition=ready --timeout=10m -n infra         flagger
-          kubectl wait helmreleases.helm.toolkit.fluxcd.io --for=condition=ready --timeout=10m -n infra         flagger-loadtester
-          kubectl wait helmreleases.helm.toolkit.fluxcd.io --for=condition=ready --timeout=10m -n infra         ingress-nginx
+          kubectl wait helmreleases.helm.toolkit.fluxcd.io --for=condition=ready --timeout=5m -n autoscaler    cluster-autoscaler
           kubectl wait helmreleases.helm.toolkit.fluxcd.io --for=condition=ready --timeout=10m -n infra         sealed-secrets
-          kubectl wait helmreleases.helm.toolkit.fluxcd.io --for=condition=ready --timeout=10m -n kube-system   descheduler
-          kubectl wait helmreleases.helm.toolkit.fluxcd.io --for=condition=ready --timeout=10m -n infra         external-dns
-          kubectl wait helmreleases.helm.toolkit.fluxcd.io --for=condition=ready --timeout=10m -n infra         oauth2-proxy
-          kubectl wait helmreleases.helm.toolkit.fluxcd.io --for=condition=ready --timeout=10m -n monitoring    prometheus-stack
+          kubectl wait helmreleases.helm.toolkit.fluxcd.io --for=condition=ready --timeout=5m -n infra         ingress-nginx
+          kubectl wait helmreleases.helm.toolkit.fluxcd.io --for=condition=ready --timeout=5m -n infra         cert-manager
+          kubectl wait helmreleases.helm.toolkit.fluxcd.io --for=condition=ready --timeout=5m -n infra         external-dns
+          kubectl wait helmreleases.helm.toolkit.fluxcd.io --for=condition=ready --timeout=5m -n infra         flagger
+          kubectl wait helmreleases.helm.toolkit.fluxcd.io --for=condition=ready --timeout=5m -n infra         flagger-loadtester
+          kubectl wait helmreleases.helm.toolkit.fluxcd.io --for=condition=ready --timeout=5m -n infra         oauth2-proxy
+          kubectl wait helmreleases.helm.toolkit.fluxcd.io --for=condition=ready --timeout=5m -n kube-system   descheduler
+          kubectl wait helmreleases.helm.toolkit.fluxcd.io --for=condition=ready --timeout=5m -n monitoring    prometheus-stack
       - name: Verify other resources
         run: |
           kubectl wait deployment --for=condition=Available --timeout=5m -n podinfo    podinfo--stg
@@ -63,8 +63,8 @@ jobs:
           flux get all --all-namespaces
           kubectl get helmreleases.helm.toolkit.fluxcd.io --all-namespaces
           helm list -A
-          kubectl describe helmreleases.helm.toolkit.fluxcd.io --all-namespaces
           kubectl -n flux-system get all
+          kubectl describe pods --all-namespaces
           kubectl -n flux-system logs deploy/source-controller
           kubectl -n flux-system logs deploy/kustomize-controller
           kubectl -n flux-system logs deploy/helm-controller

--- a/clusters/end-to-end-tests/system.yaml
+++ b/clusters/end-to-end-tests/system.yaml
@@ -13,48 +13,8 @@ spec:
   prune: true
   dependsOn:
     - name: crds
+
   patches:
-  # This patch is to cover the install process for prometheus, as it seems to try to create an ingress too quickly
-  # when the nginx-admission webhook isn't ready
-  - patch: |-
-      apiVersion: helm.toolkit.fluxcd.io/v2beta1
-      kind: HelmRelease
-      metadata:
-        name: prometheus-stack
-        namespace: monitoring
-      spec:
-        install:
-          remediation:
-            retries: 5
-    target:
-      kind: HelmRelease
-      name: prometheus-stack
-  - patch: |-
-      apiVersion: helm.toolkit.fluxcd.io/v2beta1
-      kind: HelmRelease
-      metadata:
-        name: oauth2-proxy
-        namespace: infra
-      spec:
-        install:
-          remediation:
-            retries: 5
-    target:
-      kind: HelmRelease
-      name: oauth2-proxy
-  - patch: |-
-      apiVersion: helm.toolkit.fluxcd.io/v2beta1
-      kind: HelmRelease
-      metadata:
-        name: external-dns
-        namespace: infra
-      spec:
-        install:
-          remediation:
-            retries: 5
-    target:
-      kind: HelmRelease
-      name: external-dns
   # in a small cluster like kind or minikube the load balancer won't get an external IP.
   # Therefore, we need to disable waiting
   - patch: |-

--- a/system/infra/cert-manager/release.yaml
+++ b/system/infra/cert-manager/release.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: infra
 
 spec:
-  interval: 5m
+  interval: 1m
   releaseName: infra-cert-manager
   chart:
     spec:
@@ -16,6 +16,9 @@ spec:
         kind: HelmRepository
         name: cert-manager
       interval: 1m
+  install:
+    remediation:
+      retries: 5
 
   values:
     installCRDs: false

--- a/system/infra/external-dns/release.yaml
+++ b/system/infra/external-dns/release.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: infra
 
 spec:
-  interval: 5m
+  interval: 1m
   releaseName: infra-external-dns
   chart:
     spec:
@@ -16,6 +16,9 @@ spec:
         kind: HelmRepository
         name: external-dns
       interval: 1m
+  install:
+    remediation:
+      retries: 5
 
   values:
     replicaCount: 1

--- a/system/infra/flagger/flagger-release.yaml
+++ b/system/infra/flagger/flagger-release.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: infra
 
 spec:
-  interval: 5m
+  interval: 1m
   releaseName: infra-flagger
   chart:
     spec:
@@ -16,6 +16,13 @@ spec:
         kind: HelmRepository
         name: flagger
       interval: 1m
+  install:
+    remediation:
+      retries: 5
+
+  dependsOn:
+  - name: ingress-nginx
+    namespace: infra
 
   values:
     metricsServer: http://monitoring-prometheus-stac-prometheus.monitoring:9090

--- a/system/infra/flagger/loadtester-release.yaml
+++ b/system/infra/flagger/loadtester-release.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: infra
 
 spec:
-  interval: 5m
+  interval: 1m
   releaseName: infra-flagger-loadtester
   chart:
     spec:
@@ -16,6 +16,9 @@ spec:
         kind: HelmRepository
         name: flagger
       interval: 1m
+  install:
+    remediation:
+      retries: 5
 
   values:
     rbac:

--- a/system/infra/ingress-nginx/release.yaml
+++ b/system/infra/ingress-nginx/release.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: infra
 
 spec:
-  interval: 5m
+  interval: 1m
   releaseName: infra-ingress-nginx
   chart:
     spec:
@@ -16,6 +16,11 @@ spec:
         kind: HelmRepository
         name: ingress-nginx
       interval: 1m
+
+  dependsOn:
+  - name: sealed-secrets
+    namespace: infra
+
   values:
     controller:
       config:

--- a/system/infra/oauth2-proxy/release.yaml
+++ b/system/infra/oauth2-proxy/release.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: infra
 
 spec:
-  interval: 5m
+  interval: 1m
   releaseName: infra-oauth2-proxy
   chart:
     spec:
@@ -16,6 +16,14 @@ spec:
         kind: HelmRepository
         name: oauth2-proxy
       interval: 1m
+
+  install:
+    remediation:
+      retries: 5
+
+  dependsOn:
+  - name: sealed-secrets
+    namespace: infra
 
   values:
     config:

--- a/system/infra/sealed-secrets/release.yaml
+++ b/system/infra/sealed-secrets/release.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: infra
 
 spec:
-  interval: 5m
+  interval: 1m
   releaseName: infra-sealed-secrets
   chart:
     spec:
@@ -16,6 +16,10 @@ spec:
         kind: HelmRepository
         name: sealed-secrets
       interval: 1m
+  timeout: 2m
+  install:
+    remediation:
+      retries: 5
 
   values:
     namespace: infra

--- a/system/monitoring/kube-prometheus-stack/release.yaml
+++ b/system/monitoring/kube-prometheus-stack/release.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: monitoring
 
 spec:
-  interval: 5m
+  interval: 1m
   releaseName: monitoring-prometheus-stack
   chart:
     spec:
@@ -16,6 +16,15 @@ spec:
         kind: HelmRepository
         name: prometheus-stack
       interval: 1m
+  install:
+    remediation:
+      retries: 5
+
+  dependsOn:
+  - name: ingress-nginx
+    namespace: infra
+  - name: sealed-secrets
+    namespace: infra
 
   values:
     global:


### PR DESCRIPTION
* Add install retries to all infrastructure components
* Add dependencies within system helm charts
* Add a timeout to sealed-secrets as it has been observed timing out (though this is likely due to a glitch with the registry at the time of writing)
* Reorder the CI helm charts so that earlier dependencies are checked first
* reduced the wait times in e2e tests - more determinism in the dependencies and checks has lead to lower overall reconcile time.