### PR TITLE
Add a new MongoDB release using Helm, rather than defining the release manually. 

### DIFF
--- a/deployments/epp/mongodb/mongodb-release.yaml
+++ b/deployments/epp/mongodb/mongodb-release.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: mongodb
+  namespace: epp
+
+spec:
+  interval: 1m
+  releaseName: mongodb
+  chart:
+    spec:
+      chart: psmdb-db
+      version: 1.13.0
+      sourceRef:
+        kind: HelmRepository
+        name: percona
+        namespace: db-operator-system
+      interval: 1m
+
+  values:
+    secrets:
+      users: mongodb-passwords
+    upgradeOptions:
+      apply: 5.0-recommended
+    sharding:
+      enabled: false
+    backup:
+      enabled: false
+    replsets:
+    - name: rs0
+      size: 3
+      antiAffinityTopologyKey: "kubernetes.io/hostname"
+      podDisruptionBudget:
+        maxUnavailable: 1
+      expose:
+        enabled: false
+        exposeType: ClusterIP
+      nonvoting:
+        enabled: false
+        size: 3
+        antiAffinityTopologyKey: "kubernetes.io/hostname"
+        podDisruptionBudget:
+          maxUnavailable: 1
+        resources:
+          limits:
+            cpu: "300m"
+            memory: "0.5G"
+          requests:
+            cpu: "300m"
+            memory: "0.5G"
+        volumeSpec:
+          emptyDir: {}
+      arbiter:
+        enabled: false
+        size: 1
+        antiAffinityTopologyKey: "kubernetes.io/hostname"
+      resources:
+        limits:
+          cpu: "300m"
+          memory: "0.5G"
+        requests:
+          cpu: "300m"
+          memory: "0.5G"
+      volumeSpec:
+        emptyDir: {}


### PR DESCRIPTION
This will track changes made to PerconaServerMongoDB api easier