### PR TITLE
deploy(system/kube-system/descheduler): force registry change to overcome deprecated registry

### DIFF
--- a/system/kube-system/descheduler/release.yaml
+++ b/system/kube-system/descheduler/release.yaml
@@ -16,3 +16,6 @@ spec:
         kind: HelmRepository
         name: descheduler
       interval: 1m
+  values:
+    image:
+      repository: registry.k8s.io/descheduler/descheduler

--- a/system/kube-system/descheduler/release.yaml
+++ b/system/kube-system/descheduler/release.yaml
@@ -19,4 +19,3 @@ spec:
   values:
     image:
       repository: registry.k8s.io/descheduler/descheduler
-      tag: v0.25.1

--- a/system/kube-system/descheduler/release.yaml
+++ b/system/kube-system/descheduler/release.yaml
@@ -19,3 +19,4 @@ spec:
   values:
     image:
       repository: registry.k8s.io/descheduler/descheduler
+      tag: v0.25.1


### PR DESCRIPTION
related to https://github.com/elifesciences/issues/issues/8216