### PR TITLE
deploy(clusters/end-to-end-tests,tests): Add topology labels

### DIFF
--- a/nodes/clusters/end-to-end-tests/nodes/1_large_simulated_node.yaml
+++ b/nodes/clusters/end-to-end-tests/nodes/1_large_simulated_node.yaml
@@ -12,6 +12,7 @@ metadata:
     kubernetes.io/os: linux
     kubernetes.io/role: agent
     node-role.kubernetes.io/agent: ""
+    topology.kubernetes.io/zone: fake-zone-a
     type: kwok
     Project: end-to-end-tests
   name: kwok-node-0

--- a/nodes/clusters/end-to-end-tests/nodes/4_smaller_simulated_nodes.yaml
+++ b/nodes/clusters/end-to-end-tests/nodes/4_smaller_simulated_nodes.yaml
@@ -13,6 +13,7 @@ metadata:
     kubernetes.io/os: linux
     kubernetes.io/role: agent
     node-role.kubernetes.io/agent: ""
+    topology.kubernetes.io/zone: fake-zone-b
     type: kwok
     Project: end-to-end-tests
   name: kwok-node-1
@@ -57,6 +58,7 @@ metadata:
     kubernetes.io/os: linux
     kubernetes.io/role: agent
     node-role.kubernetes.io/agent: ""
+    topology.kubernetes.io/zone: fake-zone-c
     type: kwok
   name: kwok-node-2
 spec:
@@ -100,6 +102,7 @@ metadata:
     kubernetes.io/os: linux
     kubernetes.io/role: agent
     node-role.kubernetes.io/agent: ""
+    topology.kubernetes.io/zone: fake-zone-d
     type: kwok
   name: kwok-node-3
 spec:
@@ -143,6 +146,7 @@ metadata:
     kubernetes.io/os: linux
     kubernetes.io/role: agent
     node-role.kubernetes.io/agent: ""
+    topology.kubernetes.io/zone: fake-zone-e
     type: kwok
   name: kwok-node-4
 spec:

--- a/tests/run_cluster_in_kind.sh
+++ b/tests/run_cluster_in_kind.sh
@@ -23,6 +23,8 @@ flux install --components-extra="image-reflector-controller,image-automation-con
 kubectl label node "$name-control-plane" Project="end-to-end-tests"
 # taint the current node to not schedule workloads by default
 kubectl taint node "$name-control-plane" realnode=true:NoSchedule
+# Add a label for topology tests to work
+kubectl label node "$name-control-plane" topology.kubernetes.io/zone=fake-zone-a
 
 # Install gitops stuff and wait
 flux create source git flux-system --url="$repo" --branch="$branch"


### PR DESCRIPTION
Add topology labels so that we can effectively test topology aware deployments